### PR TITLE
Fix digit guard range

### DIFF
--- a/Sources/SwiftTerm/ExternsionsTerminal.swift
+++ b/Sources/SwiftTerm/ExternsionsTerminal.swift
@@ -10,7 +10,7 @@ import Foundation
 extension UInt8 {
     // ascii codes 48 '0' through 57 '9' return as their digit
     var digit: Int? {
-        guard self >= 48 && self <= 59 else {
+        guard self >= 48 && self <= 57 else {
             return nil
         }
         return Int(self) - 48


### PR DESCRIPTION
## Summary
- correct guard condition for `UInt8.digit` so it only accepts ASCII digits

## Testing
- `swift test -l` *(fails: no such module 'CoreText')*

------
https://chatgpt.com/codex/tasks/task_e_68856dd1f3ec8330be0cad0b041eb125