### PR TITLE
Improve emoji handling

### DIFF
--- a/Sources/SwiftTerm/Utilities.swift
+++ b/Sources/SwiftTerm/Utilities.swift
@@ -320,4 +320,16 @@ struct UnicodeUtil {
               (irune >= 0x30000 && irune <= 0x3fffd)) ||
               bisearch(rune: irune, table: twoColumnEmoji, max: twoColumnEmoji.count-1) != 0) ? 1 : 0)
     }
+
+    /// Computes the column width for a full Swift `Character` taking into account
+    /// all the contained Unicode scalars.
+    /// - Parameter character: The character to measure
+    /// - Returns: The number of columns required to display `character` on screen.
+    static func columnWidth (character: Character) -> Int {
+        var width = 0
+        for scalar in String(character).unicodeScalars {
+            width = max (width, columnWidth (rune: scalar))
+        }
+        return width
+    }
 }


### PR DESCRIPTION
## Summary
- add `UnicodeUtil.columnWidth` for `Character`
- accumulate grapheme clusters when printing characters

## Testing
- `swift build` *(fails: no such module 'CoreText')*
- `swift test` *(fails: no such module 'CoreText')*

------
https://chatgpt.com/codex/tasks/task_e_68856ce89a648330a73e5bfdc96fedf8